### PR TITLE
Fix loguru sinks

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -10,5 +10,6 @@ services:
     tty: true
     volumes:
       - ./tyrant:/tyrant/tyrant:ro
+      - ./logs:/tyrant/logs
     env_file:
       - .env

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,3 +8,5 @@ services:
     restart: always
     env_file:
       - .env
+    volumes:
+      - ./logs:/tyrant/logs

--- a/tyrant/__init__.py
+++ b/tyrant/__init__.py
@@ -38,4 +38,5 @@ logger.remove()
 
 # Define logger format and add the sink.
 logger_format = "{time:YYYY-MM-DD at HH:mm:ss} | {level} | {name}:{line} | {message}"
-logger.add(sys.stdout, format=logger_format, retention="7 days", rotation="10 MB")
+logger.add(sys.stdout, format=logger_format)
+logger.add("logs/tyrant_log.log", format=logger_format, retention="7 days", rotation="10 MB")


### PR DESCRIPTION
This removes the retention and rotation kwargs from the sys.stdout sink, as they are not supported, and addes a file sink.

This commit also adds docker-compose volumes, so that the log files are available on the host machine.